### PR TITLE
Correct location of migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ add plugin to your `tsconfig.json`:
 ```
 and run the migration script
 ```
-update-strict-comments
+./node_modules/.bin/update-strict-comments
 ```
 That's it! You should be able to see strict typechecking in files without the `@ts-strict-ignore` comment. To make these files strict too, just remove its' ignore comments.
 


### PR DESCRIPTION
Just a small README update: AFAIK you can only invoke an npm package script directly if it's run via a defined npm script or `node_modules/.bin` has been added to your path (not default for most people). Since this only needs to be run once, this should make it clear how to invoke the script for people not familiar with packages that ship with them