### PR TITLE
Add exclude to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.2.0] - 2022-10-17
 
 ### Added
+
 - Add feature to exclude files from strict check based on `exclude` config property
 
 ## [2.1.0] - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2022-10-17
+
+### Added
+- Add feature to exclude files from strict check based on `exclude` config property
+
 ## [2.1.0] - 2022-10-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ comment. To make these files strict too, just remove its' ignore comments.
 
 ## Configuration
 
-Plugin takes extra, non-mandatory arguments `paths` and `exlude`. Both of them take an array of relative or absolute paths that should be included (property `paths`) or excluded (property `exclude`). To add strict mode to files from ignored paths you can insert `//@ts-strict` comment.
+Plugin takes extra, non-mandatory arguments `paths` and `exlude`. Both of them take an array of
+relative or absolute paths that should be included (property `paths`) or excluded (property
+`exclude`). To add strict mode to files from ignored paths you can insert `//@ts-strict` comment.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ comment. To make these files strict too, just remove its' ignore comments.
 
 ## Configuration
 
-Plugin takes one extra non-mandatory argument `paths` that is an array of relative or absolute paths
-of directories that should be included. To add strict mode to files from ignored paths you can
-insert `//@ts-strict` comment.
+Plugin takes extra, non-mandatory arguments `paths` and `exlude`. Both of them take an array of relative or absolute paths that should be included (property `paths`) or excluded (property `exclude`). To add strict mode to files from ignored paths you can insert `//@ts-strict` comment.
 
 ```json
 {
@@ -75,6 +73,10 @@ insert `//@ts-strict` comment.
         "paths": [
           "./src",
           "/absolute/path/to/source/"
+        ],
+        "exclude": [
+          "./src/tests",
+          "./src/fileToExclude.ts"
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-strict-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Typescript tools that help with migration to the strict mode",
   "author": "Allegro",
   "contributors": [

--- a/src/common/__tests__/isFileStrict.spec.ts
+++ b/src/common/__tests__/isFileStrict.spec.ts
@@ -41,6 +41,20 @@ describe('isFileStrict', () => {
     expect(result).toBe(true);
   });
 
+  it('should return true when strict comment is present and file is excluded', () => {
+    // given
+    isCommentPresent.mockImplementation((comment) => comment === '@ts-strict');
+    const config: Config = {
+      exclude: [filePath],
+    };
+
+    // when
+    const result = isFileStrict({ filePath, isCommentPresent, config });
+
+    // then
+    expect(result).toBe(true);
+  });
+
   it('should return false when both strict and ignore update-strict-comments are present', () => {
     // given
     isCommentPresent.mockImplementation(
@@ -110,10 +124,52 @@ describe('isFileStrict', () => {
     expect(result).toBe(false);
   });
 
+  it('should return false when file is on path and in exclude', () => {
+    // given
+    const config: Config = {
+      paths: ['otherFilePath', filePath, 'otherFilePath'],
+      exclude: [filePath],
+    };
+
+    // when
+    const result = isFileStrict({ filePath, isCommentPresent, config });
+
+    // then
+    expect(result).toBe(false);
+  });
+
   it('should return true when path config is empty', () => {
     // given
     const config: Config = {
       paths: [],
+    };
+
+    // when
+    const result = isFileStrict({ filePath, isCommentPresent, config });
+
+    // then
+    expect(result).toBe(true);
+  });
+
+  it('should return false when path config is empty and file is excluded', () => {
+    // given
+    const config: Config = {
+      paths: [],
+      exclude: [filePath],
+    };
+
+    // when
+    const result = isFileStrict({ filePath, isCommentPresent, config });
+
+    // then
+    expect(result).toBe(false);
+  });
+
+  it('should return true when path config is empty and different file is excluded (check for false-positive)', () => {
+    // given
+    const config: Config = {
+      paths: [],
+      exclude: ['otherFile'],
     };
 
     // when

--- a/src/common/isFileExcludedByPath.ts
+++ b/src/common/isFileExcludedByPath.ts
@@ -1,0 +1,26 @@
+import { isFileOnPath } from './isFileOnPath';
+
+interface IsFileExcludedByPathParams {
+  filePath: string;
+  projectPath?: string;
+  configExclude?: string[];
+}
+
+export function isFileExcludedByPath({
+  filePath,
+  projectPath,
+  configExclude,
+}: IsFileExcludedByPathParams): boolean {
+  if (configExclude === undefined) {
+    console.log('No Exludes detected');
+    return false;
+  }
+
+  return configExclude?.some((path) =>
+    isFileOnPath({
+      filePath,
+      targetPath: path,
+      projectPath,
+    }),
+  );
+}

--- a/src/common/isFileExcludedByPath.ts
+++ b/src/common/isFileExcludedByPath.ts
@@ -12,7 +12,6 @@ export function isFileExcludedByPath({
   configExclude,
 }: IsFileExcludedByPathParams): boolean {
   if (configExclude === undefined) {
-    console.log('No Exludes detected');
     return false;
   }
 

--- a/src/common/isFileStrict.ts
+++ b/src/common/isFileStrict.ts
@@ -1,6 +1,7 @@
 import { Config } from './types';
 import { isFileStrictByPath } from './isFileStrictByPath';
 import { TS_STRICT_COMMENT, TS_STRICT_IGNORE_COMMENT } from './constants';
+import { isFileExcludedByPath } from './isFileExcludedByPath';
 
 type IsFileStrictConfig = {
   filePath: string;
@@ -22,6 +23,18 @@ export function isFileStrict({
 
   if (isCommentPresent(TS_STRICT_COMMENT, filePath)) {
     return true;
+  }
+
+  const configExclude = config?.exclude ?? [];
+
+  if (
+    isFileExcludedByPath({
+      filePath,
+      configExclude,
+      projectPath,
+    })
+  ) {
+    return false;
   }
 
   const configPaths = config?.paths ?? [];

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,4 @@
 export interface Config {
   paths?: string[];
+  exclude?: string[];
 }


### PR DESCRIPTION
This PR partially solves issue https://github.com/allegro/typescript-strict-plugin/issues/39 by adding option to exclude files. To fully resolve that issue, option to create paths with globs is needed.

This PR addresses three places where file paths are checked. Please take a look if I haven't missed anything. Addressed places are:
* IDE check and cli tsc-strict use isFileStrict.ts to decide which files to check
* cli update-strict-comments checks files at few different stages. This implementation checks them during first search for the files (index.ts -> findStrictFiles). So files that are excluded will not later go through the process of adding/removing comments.

The priority of checks according to new isFileStrict.ts will be:
1. ts strict ignore comment
2. ts strict comment
3. exclude
4. include
To give an example, if file is both in include and exclude, it will be excluded. If it has @ts-strict and exclude, it will be included.