### PR TITLE
Use in-memory program to generate strict diagnostics for plugin

### DIFF
--- a/src/plugin/InMemoryProgram.ts
+++ b/src/plugin/InMemoryProgram.ts
@@ -1,7 +1,20 @@
 import { PluginInfo } from './utils';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
+/**
+ * djb2 hashing algorithm
+ * http://www.cse.yorku.ca/~oz/hash.html
+ */
+function generateDjb2Hash(data: string): string {
+  let acc = 5381;
+  for (let i = 0; i < data.length; i++) {
+    acc = (acc << 5) + acc + data.charCodeAt(i);
+  }
+  return acc.toString();
+}
+
 export class InMemoryProgram {
+  private host: undefined | ts.CompilerHost = undefined;
   private program: undefined | ts.SemanticDiagnosticsBuilderProgram = undefined;
 
   constructor(
@@ -9,10 +22,27 @@ export class InMemoryProgram {
     private readonly info: PluginInfo,
   ) {}
 
-  private getSourceFile(fileName: string) {
+  private getSourceFile(
+    fileName: string,
+    languageVersionOrOptions?: ts.ScriptTarget | ts.CreateSourceFileOptions,
+  ) {
     // Assume the file is canonicalized and absolute.
     const path = fileName as ts.Path;
-    const sourceFile = this.info.project.getSourceFile(path);
+    let sourceFile = this.info.project.getSourceFile(path);
+
+    // This case occurs when trying to resolve .d.ts outputs of project references.
+    if (!sourceFile && languageVersionOrOptions) {
+      sourceFile = this.host?.getSourceFile(fileName, languageVersionOrOptions);
+
+      if (sourceFile) {
+        // SemanticDiagnosticBuilder requires that the file has a version.
+        // We use the same hashing function that is used in the TypeScript repo as fallback.
+        (sourceFile as ts.SourceFile & { version: string }).version = generateDjb2Hash(
+          sourceFile.text,
+        );
+      }
+    }
+
     return sourceFile;
   }
 
@@ -24,12 +54,15 @@ export class InMemoryProgram {
 
     const rootFiles = [...currentProgram.getRootFileNames()];
     const options = { ...currentProgram.getCompilerOptions(), strict: true };
+    this.host = this._ts.createCompilerHost(options);
     const compilerHost: ts.CompilerHost = {
-      ...this._ts.createCompilerHost(options),
+      ...this.host,
 
       // Assume we can ignore the other arguments to these function.
-      getSourceFile: (fileName) => this.getSourceFile(fileName),
-      getSourceFileByPath: (fileName) => this.getSourceFile(fileName),
+      getSourceFile: (fileName, languageVersionOrOptions) =>
+        this.getSourceFile(fileName, languageVersionOrOptions),
+      getSourceFileByPath: (fileName, path, languageVersionOrOptions) =>
+        this.getSourceFile(fileName, languageVersionOrOptions),
     };
     const configFileParsingDiagnostics = currentProgram.getConfigFileParsingDiagnostics();
     const projectReferences = currentProgram.getProjectReferences();

--- a/src/plugin/InMemoryProgram.ts
+++ b/src/plugin/InMemoryProgram.ts
@@ -1,0 +1,46 @@
+import { PluginInfo } from './utils';
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+export class InMemoryProgram {
+  private program: undefined | ts.SemanticDiagnosticsBuilderProgram = undefined;
+
+  constructor(
+    private readonly _ts: typeof ts,
+    private readonly info: PluginInfo,
+  ) {}
+
+  private getSourceFile(
+    fileName: string,
+    languageVersionOrOptions?: ts.ScriptTarget | ts.CreateSourceFileOptions,
+    onError?: (message: string) => void,
+    shouldCreateNewSourceFile?: boolean,
+  ) {
+    const path = fileName as ts.Path;
+    const sourceFile = this.info.project.getSourceFile(path);
+    return sourceFile;
+  }
+
+  public getSemanticDiagnostics(filePath: string): ts.Diagnostic[] {
+    const currentProgram = this.info.languageService.getProgram();
+    if (!currentProgram) {
+      return this.info.languageService.getSemanticDiagnostics(filePath);
+    }
+
+    const rootFiles = [...currentProgram.getRootFileNames()];
+    const options = { ...currentProgram.getCompilerOptions(), strict: true };
+    const compilerHost: ts.CompilerHost = {
+      ...this._ts.createCompilerHost(options),
+      getSourceFile: (...args) => this.getSourceFile(...args),
+      getSourceFileByPath: (fileName, filePath, ...args) => this.getSourceFile(fileName, ...args),
+    };
+    this.program = this._ts.createSemanticDiagnosticsBuilderProgram(
+      rootFiles,
+      options,
+      compilerHost,
+      this.program,
+    );
+
+    const strictDiags = this.program.getSemanticDiagnostics(this.getSourceFile(filePath));
+    return [...strictDiags];
+  }
+}


### PR DESCRIPTION
The PR changes the strategy used to generate the strict diagnostics in the plugin by keeping an in-memory version of the TypeScript program instead of mutating the existing program used by the language service. 

The in-memory version is a `SemanticDiagnosticsBuilderProgram` which the same type used in the TypeScript API example ["Writing an incremental program watcher"](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#writing-an-incremental-program-watcher). This program type is partially internal since it requires that `SourceFile`s produced by the compiler host are versioned (which is an internal property). Luckily the language service produces versioned source files of the files currently being edited. I have only found one case where this does not happen which is when importing from [reference projects](https://www.typescriptlang.org/docs/handbook/project-references.html), in particular it seems the language service does not keep track of the declaration files of referenced projects. In this case we fallback to the standard compiler host and generate a file version using a hashing algorithm which is also used as a fallback in the [TypeScript repo](https://github.com/microsoft/TypeScript/blob/main/src/compiler/sys.ts#L59-L65).

I have tried to document assumptions made. This PR does not contain any tests and I have not looked at the non-plugin code to see if there is any possibility for code sharing. I have mainly implemented this to resolve https://github.com/allegro/typescript-strict-plugin/issues/61 for a project where I introduced this plugin (and would be very sad to lose it).

Fixes: https://github.com/allegro/typescript-strict-plugin/issues/61