### PR TITLE
Add in-memory strict language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-strict-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Typescript tools that help with migration to the strict mode",
   "author": "Allegro",
   "contributors": [

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,22 +1,29 @@
 import { PluginStrictFileChecker } from './PluginStrictFileChecker';
-import { log, PluginInfo, setupProxy, turnOffStrictMode, turnOnStrictMode } from './utils';
+import {
+  log,
+  PluginInfo,
+  setupLanguageServiceProxy,
+  setupStrictLanguageServiceHostProxy,
+} from './utils';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-const init: ts.server.PluginModuleFactory = () => {
+const init: ts.server.PluginModuleFactory = ({ typescript }) => {
   function create(info: PluginInfo) {
-    const proxy = setupProxy(info);
+    const proxy = setupLanguageServiceProxy(info);
+
+    const strictLanguageServiceHost = setupStrictLanguageServiceHostProxy(info);
+    const strictLanguageService = typescript.createLanguageService(strictLanguageServiceHost);
+
     log(info, 'Plugin initialized');
 
     proxy.getSemanticDiagnostics = function (filePath) {
       const strictFile = new PluginStrictFileChecker(info).isFileStrict(filePath);
 
       if (strictFile) {
-        turnOnStrictMode(info);
+        return strictLanguageService.getSemanticDiagnostics(filePath);
       } else {
-        turnOffStrictMode(info);
+        return info.languageService.getSemanticDiagnostics(filePath);
       }
-
-      return info.languageService.getSemanticDiagnostics(filePath);
     };
 
     return proxy;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -25,6 +25,14 @@ const init: ts.server.PluginModuleFactory = ({ typescript }) => {
         return info.languageService.getSemanticDiagnostics(filePath);
       }
     };
+    proxy.cleanupSemanticCache = function () {
+      strictLanguageService.cleanupSemanticCache();
+      info.languageService.cleanupSemanticCache();
+    };
+    proxy.dispose = function () {
+      strictLanguageService.dispose();
+      info.languageService.dispose();
+    };
 
     return proxy;
   }

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -3,15 +3,7 @@ import { PLUGIN_NAME } from '../common/constants';
 
 export type PluginInfo = ts.server.PluginCreateInfo;
 
-export function turnOnStrictMode(info: PluginInfo): void {
-  info.project['compilerOptions'].strict = true;
-}
-
-export function turnOffStrictMode(info: PluginInfo): void {
-  info.project['compilerOptions'].strict = false;
-}
-
-export function setupProxy(info: PluginInfo) {
+export function setupLanguageServiceProxy(info: PluginInfo) {
   const proxy: ts.LanguageService = Object.create(null);
   for (const k of Object.keys(info.languageService) as Array<keyof ts.LanguageService>) {
     const serviceFunction = info.languageService[k];
@@ -19,6 +11,23 @@ export function setupProxy(info: PluginInfo) {
     proxy[k] = (...args: Array<unknown>) => serviceFunction!.apply(info.languageService, args);
   }
 
+  return proxy;
+}
+
+export function setupStrictLanguageServiceHostProxy(info: PluginInfo): ts.LanguageServiceHost {
+  const host = info.languageServiceHost;
+  const strictGetCompilationSettings = () => {
+    const settings = info.languageServiceHost.getCompilationSettings();
+    return { ...settings, strict: true };
+  };
+  const proxy = new Proxy(host, {
+    get(target, prop, receiver) {
+      if (prop === 'getCompilationSettings') {
+        return strictGetCompilationSettings;
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
   return proxy;
 }
 


### PR DESCRIPTION
Implementation of approach that I described in [#62](https://github.com/allegro/typescript-strict-plugin/pull/62#issuecomment-1892837734). TL;DR: Create a strict `LanguageService` in memory and `getSemanticDiagnostics` from it for all strict files.

The `create` method in a plugin returns a `LanguageService`, and a `LanguageService`'s entire view of the world is through a `LanguageServiceHost`. By proxying _only_ `getCompilationSettings` on `LanguageServiceHost` to add `strict: true` and creating a new `LanguageService` from it, we create a perfect mirror of the stock `LanguageService` but with strict enabled.

Proxying the `LanguageServiceHost` was more difficult than the language server, as `Object.keys(host)` did not return all required methods. I tried grabbing the methods to proxy by walking up the prototype chain, but ultimately I couldn't figure it out; every time I'd be missing some other property and get some variant of a "cant access x on undefined" exception in the tsserver logs. Using a [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) seems to have done the trick, and I'm successfully using this in my work repo now.

I also proxied `dispose` and `cleanupSemanticCache` as they seemed important to the `LanguageService` lifecycle. I have no idea if they're necessary.
