### PR TITLE
Don't match path on prefix alone

### DIFF
--- a/src/common/isFileOnPath.ts
+++ b/src/common/isFileOnPath.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { getPosixFilePath } from './utils';
 import { getAbsolutePath } from './getAbsolutePath';
 import { getProjectPathFromArgs } from './utils';
@@ -19,5 +20,7 @@ export function isFileOnPath({
 
   const absolutePathToStrictFiles = getAbsolutePath(projectPath, targetPath);
 
-  return getPosixFilePath(filePath).startsWith(getPosixFilePath(absolutePathToStrictFiles));
+  return getPosixFilePath(filePath).startsWith(
+    getPosixFilePath(absolutePathToStrictFiles) + path.posix.sep,
+  );
 }


### PR DESCRIPTION
Noticed that `path/to/good` was matching `path/to/goodness-no/file.ts`, so just the prefix and not the exact directory. I will maybe add tests this weekend.