### PR TITLE
Provide strict quick info in plugin

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -33,6 +33,15 @@ const init: ts.server.PluginModuleFactory = ({ typescript }) => {
       strictLanguageService.dispose();
       info.languageService.dispose();
     };
+    proxy.getQuickInfoAtPosition = function (filePath, position) {
+      const strictFile = new PluginStrictFileChecker(info).isFileStrict(filePath);
+
+      if (strictFile) {
+        return strictLanguageService.getQuickInfoAtPosition(filePath, position);
+      } else {
+        return info.languageService.getQuickInfoAtPosition(filePath, position);
+      }
+    };
 
     return proxy;
   }


### PR DESCRIPTION
This PR overrides the `getQuickInfoAtPosition` function on the LS proxy object in the plugin. Quick info shows up e.g. when hovering your cursor over a variable (see screenshots). It is important to show the correct type here since this is a way to evaluate type functions.

**Without override:** 

![unstrict](https://github.com/allegro/typescript-strict-plugin/assets/5310344/7c7faf99-124e-491d-8e47-603bac862825)

**With override:**

![strict](https://github.com/allegro/typescript-strict-plugin/assets/5310344/1d98f46e-52df-4ae8-a885-c5e8aeb96713)
