### PR TITLE
The program object in the strict language service is no longer undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2024-04-09
+
+### Fixed
+
+- The strict language service program object is no longer undefined
+
 ## [2.4.1] - 2024-04-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-strict-plugin",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-strict-plugin",
-      "version": "2.4.0",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-strict-plugin",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Typescript tools that help with migration to the strict mode",
   "author": "Allegro",
   "contributors": [

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -7,13 +7,12 @@ import {
 } from './utils';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-const init: ts.server.PluginModuleFactory = ({ typescript }) => {
+const init: ts.server.PluginModuleFactory = () => {
   function create(info: PluginInfo) {
     const proxy = setupLanguageServiceProxy(info);
 
     const strictLanguageServiceHost = setupStrictLanguageServiceHostProxy(info);
-    const strictLanguageService = typescript.createLanguageService(strictLanguageServiceHost);
-    strictLanguageService.getProgram();
+    const strictLanguageService = ts.createLanguageService(strictLanguageServiceHost);
 
     log(info, 'Plugin initialized');
 


### PR DESCRIPTION
The TypeScript instance retrieved from PluginModuleFactory parameters didn't match the one imported from `typescript/lib/tsserverlibrary`, causing the `createLanguageService` function to return a broken service with no program object inside. 

The solution standardizes the usage to utilize a single instance of TypeScript and eliminates the `.getProgram` call since it's a getter function that doesn't perform any action.