### PR TITLE
fix: tsc-strict does not return a failure exit code with SIGABRT

### DIFF
--- a/src/cli/typescript/typescript.ts
+++ b/src/cli/typescript/typescript.ts
@@ -30,7 +30,7 @@ export const compile = async (): Promise<string> => {
     if (isExecaError(error) && error.all) {
       if (wasCompileAborted(error)) {
         console.log(`💥 Typescript task was aborted. Full error log: `, error.all);
-        process.exit(error.exitCode);
+        process.exit(error.exitCode ?? 1);
       }
 
       compilerOutputCache = error.all;


### PR DESCRIPTION
According to execa docs the error might contain an undefined exitCode when it gets killed by a signal or fails when spawning.

https://github.com/sindresorhus/execa/blob/main/docs/errors.md#exit-code

To test I did the following locally to simulate the TSC getting out of memory:

```
NODE_OPTIONS="--max-old-space-size=512" ../node_modules/.bin/tsc-strict
echo $?
```