### PR TITLE
Fixed file paths broke by adding `/` to every paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-strict-plugin",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-strict-plugin",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^3.0.0",

--- a/src/common/isFileOnPath.ts
+++ b/src/common/isFileOnPath.ts
@@ -20,7 +20,9 @@ export function isFileOnPath({
 
   const absolutePathToStrictFiles = getAbsolutePath(projectPath, targetPath);
 
-  return getPosixFilePath(filePath).startsWith(
-    getPosixFilePath(absolutePathToStrictFiles) + path.posix.sep,
+  const posixFilePath = getPosixFilePath(filePath);
+  const posixStrictPath = getPosixFilePath(absolutePathToStrictFiles);
+  return (
+    posixFilePath === posixStrictPath || posixFilePath.startsWith(posixStrictPath + path.posix.sep)
   );
 }


### PR DESCRIPTION
Hi!

Fixed a bug introduced by https://github.com/allegro/typescript-strict-plugin/pull/68.
Used @heyimalex https://github.com/allegro/typescript-strict-plugin/pull/68#issuecomment-2043216933 to do so.

Thanks!